### PR TITLE
Remove `_` in secret names to support kompose

### DIFF
--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -17,6 +17,8 @@ jobs:
         run: |
           export TAG=$(git rev-parse --short "$GITHUB_SHA")
           docker compose -f compose.prod.yaml build
+          export TAG=latest
+          docker compose -f compose.prod.yaml build
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -27,6 +29,8 @@ jobs:
       - name: Push to hub
         run: |
           export TAG=$(git rev-parse --short "$GITHUB_SHA")
+          docker compose -f compose.prod.yaml push
+          export TAG=latest
           docker compose -f compose.prod.yaml push
 
   build-dev-containers:

--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -17,8 +17,6 @@ jobs:
         run: |
           export TAG=$(git rev-parse --short "$GITHUB_SHA")
           docker compose -f compose.prod.yaml build
-          export TAG=latest
-          docker compose -f compose.prod.yaml build
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -29,8 +27,6 @@ jobs:
       - name: Push to hub
         run: |
           export TAG=$(git rev-parse --short "$GITHUB_SHA")
-          docker compose -f compose.prod.yaml push
-          export TAG=latest
           docker compose -f compose.prod.yaml push
 
   build-dev-containers:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -4,7 +4,7 @@ services:
   database:
     image: mariadb:11
     environment:
-      MARIADB_ROOT_PASSWORD_FILE: /run/secrets/mariadb_password
+      MARIADB_ROOT_PASSWORD_FILE: /run/secrets/mariadb-password
     restart: always
     healthcheck:
       test: ["CMD", "bash", "/usr/local/bin/healthcheck.sh", "--connect"]
@@ -12,7 +12,7 @@ services:
       timeout: 5s
       retries: 3
     secrets:
-      - mariadb_password
+      - mariadb-password
   # In memory cache for helioviewer
   redis:
     image: redis:latest
@@ -28,8 +28,8 @@ services:
       dockerfile: ./compose.prod/dockerfiles/db_init.prod.Dockerfile
       context: .
     secrets:
-      - api_settings
-      - db_setup_script
+      - api-settings
+      - db-setup-script
     volumes:
       - jp2_volume:/tmp/jp2
   api:
@@ -57,11 +57,11 @@ services:
     volumes:
       - cache:/var/www/helioviewer.org/cache
       - cache:/var/www/api.helioviewer.org/docroot/cache
-      - api_logs:/var/www/api.helioviewer.org/log
+      - api-logs:/var/www/api.helioviewer.org/log
       - jp2_volume:/tmp/jp2
     secrets:
-      - api_config
-      - api_private
+      - api-config
+      - api-private
   web:
     image: dgarciabriseno/helioviewer-web:${TAG}
     build:
@@ -75,8 +75,9 @@ services:
     volumes:
       - cache:/var/www/html/cache
     secrets:
-      - api_config
-      - api_private
+      - api-config
+      - api-private
+      - config-js
   movies:
     image: dgarciabriseno/helioviewer-movies:${TAG}
     depends_on:
@@ -92,8 +93,8 @@ services:
       - cache:/var/www/helioviewer.org/cache
       - movie_logs:/var/www/api.helioviewer.org/log
     secrets:
-      - api_config
-      - api_private
+      - api-config
+      - api-private
   soho:
     image: dgarciabriseno/helioviewer-downloader:${TAG}
     command: "-d hv_soho"
@@ -107,7 +108,7 @@ services:
     volumes:
       - jp2_volume:/tmp/jp2
     secrets:
-      - api_settings
+      - api-settings
   sdo:
     image: dgarciabriseno/helioviewer-downloader:${TAG}
     command: "-d lmsal"
@@ -121,7 +122,7 @@ services:
     volumes:
       - jp2_volume:/tmp/jp2
     secrets:
-      - api_settings
+      - api-settings
   stereo:
     image: dgarciabriseno/helioviewer-downloader:${TAG}
     command: "-d hv_stereo"
@@ -135,22 +136,24 @@ services:
     volumes:
       - jp2_volume:/tmp/jp2
     secrets:
-      - api_settings
+      - api-settings
 
 volumes:
   jp2_volume:
   cache:
-  api_logs:
+  api-logs:
   movie_logs:
 
 secrets:
-  mariadb_password:
-    file: secrets/mariadb_password
-  api_config:
+  mariadb-password:
+    file: secrets/mariadb-password
+  api-config:
     file: secrets/Config.ini
-  api_private:
+  api-private:
     file: secrets/Private.php
-  api_settings:
+  api-settings:
     file: secrets/settings.cfg
-  db_setup_script:
+  db-setup-script:
     file: secrets/headless_setup.sh
+  config-js:
+    file: secrets/Config.js

--- a/compose.prod/scripts/api.prod.startup.sh
+++ b/compose.prod/scripts/api.prod.startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash --login
 set -e
-cp /run/secrets/api_config /var/www/api.helioviewer.org/settings/Config.ini
-cp /run/secrets/api_private /var/www/api.helioviewer.org/settings/Private.php
+cp /run/secrets/api-config /var/www/api.helioviewer.org/settings/Config.ini
+cp /run/secrets/api-private /var/www/api.helioviewer.org/settings/Private.php
 
 export PATH=$PATH:/tmp/miniforge3/bin
 READY_FILE=/tmp/container_ready

--- a/compose.prod/scripts/downloader.sh
+++ b/compose.prod/scripts/downloader.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 cd ~/api/install
-cp /run/secrets/api_settings settings/settings.cfg
+cp /run/secrets/api-settings settings/settings.cfg
 python downloader.py $@

--- a/compose.prod/scripts/init_db.sh
+++ b/compose.prod/scripts/init_db.sh
@@ -2,8 +2,8 @@
 READY_FILE=/tmp/ready
 rm -f $READY_FILE
 set -e
-cp /run/secrets/api_settings api/install/settings/settings.cfg
-cp /run/secrets/db_setup_script headless_setup.sh
+cp /run/secrets/api-settings api/install/settings/settings.cfg
+cp /run/secrets/db-setup-script headless_setup.sh
 cp /tmp/2021_06_01__00_01_29_132__SDO_AIA_AIA_304.jp2 /tmp/jp2
 chmod +x headless_setup.sh
 ./headless_setup.sh

--- a/compose.prod/scripts/movie.sh
+++ b/compose.prod/scripts/movie.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cp /run/secrets/api_config  /var/www/api.helioviewer.org/settings/Config.ini
-cp /run/secrets/api_private /var/www/api.helioviewer.org/settings/Private.php
+cp /run/secrets/api-config  /var/www/api.helioviewer.org/settings/Config.ini
+cp /run/secrets/api-private /var/www/api.helioviewer.org/settings/Private.php
 cd /var/www/api.helioviewer.org/scripts
 tcsh movie_queue.tcsh && tail -F /dev/null

--- a/compose.prod/scripts/web.prod.startup.sh
+++ b/compose.prod/scripts/web.prod.startup.sh
@@ -1,7 +1,7 @@
 set -e
-cp /run/secrets/api_config /var/www/api.helioviewer.org/settings/Config.ini
-cp /run/secrets/api_private /var/www/api.helioviewer.org/settings/Private.php
-cp /run/secrets/config_js /var/www/html/resources/js/Utility/Config.js
+cp /run/secrets/api-config /var/www/api.helioviewer.org/settings/Config.ini
+cp /run/secrets/api-private /var/www/api.helioviewer.org/settings/Private.php
+cp /run/secrets/config-js /var/www/html/resources/js/Utility/Config.js
 cd /var/www/html/resources/build
 ant
 source /etc/apache2/envvars


### PR DESCRIPTION
This makes generating the base kubernetes configuration with kompose easier, since kubernetes doesn't allow `_` in secret names.