### PR TITLE
Update coordinator to v0.3.3

### DIFF
--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Build containers
         run: docker compose build
 
+      - name: Check that containers start and become healthy
+        run: docker compose up -d --wait
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,7 @@ services:
   # Supporting python api for the helioviewer api
   coordinator:
     restart: always
-    image: dgarciabriseno/hv-coordinator:0.3.1
+    image: dgarciabriseno/hv-coordinator:0.3.3
     ports:
       - 8000:80
   api:


### PR DESCRIPTION
For some reason v0.3.1 was not working in API tests, not becoming healthy even though container logs show 200 OK for the health checks. v0.3.3 fixes a bug with the /hpc endpoint and increases the timeout for the health check.